### PR TITLE
minor fix to mean method for ros object in cenpermanova.

### DIFF
--- a/R/ROSci.R
+++ b/R/ROSci.R
@@ -44,7 +44,7 @@ ROSci <- function(cenros.out, conf=0.95,printstat=TRUE) {
     # For the default lognormal distribution, Cox’s method is used.
     scale <- as.vector(cenros.out[1]$coefficients[2])
     #  coefficient #2 is the scale, the sd of the logs
-    bhat <- log(mean(cenros.out))
+    bhat <- log(NADA:::mean(cenros.out))
     #  Mean log plus one-half scale^2 ;  the mean transformed to log units
     gamz <- qt(p,(n-1)) * sqrt((scale^2/n) + (((0.5)*scale^4)/(n-1)))
     #  Zhou and Gao 1997 modified Cox’s method for the CI of a lognormal distribution
@@ -61,7 +61,7 @@ ROSci <- function(cenros.out, conf=0.95,printstat=TRUE) {
   else { # for a gaussian distribution;
     tstat <- qt(p,(n-1))
     halfw <- tstat*(sd(cenros.out)/sqrt(n))
-    ciNorm <- c(mean(cenros.out) - halfw, mean(cenros.out) + halfw)
+    ciNorm <- c(NADA:::mean(cenros.out) - halfw, NADA:::mean(cenros.out) + halfw)
 
     rslt<-data.frame(LCL=ciNorm[1],UCL=ciNorm[2])
     if(printstat==TRUE){

--- a/R/cenpermanova.R
+++ b/R/cenpermanova.R
@@ -67,7 +67,7 @@ cenpermanova <- function(y1, y2, grp, R = 9999,printstat=TRUE) {
   # group means
   for (i in 1:nlevels(Factor)) {
     ros.out <- suppressWarnings(cenros(x1[Factor == grpname[i]], as.logical(x2[Factor == grpname[i]])))
-    group.means[i] <- signif(mean(ros.out$modeled),4)
+    group.means[i] <- signif(NADA::mean(ros.out$modeled),4)
     mean.names[i] <- paste("mean(", gpname[i], ")", sep="")
   }
   names(group.means) <- mean.names


### PR DESCRIPTION
Hi - just another situation where the mean method for ROS is not finding itself. Changed to explicitly call `NADA::mean`.