### PR TITLE
fix call of enparCensored

### DIFF
--- a/R/cfit.R
+++ b/R/cfit.R
@@ -84,7 +84,7 @@ cfit <- function(y, cens, conf=0.95, qtls = c(0.10, 0.25, 0.50, 0.75, 0.90),
   y.out<- survfit(y.surv ~ 1, conf.int = conf, conf.type = "plain")
 
   # left.censored.min="DL" is the Efron bias correction, generally standard for Kaplan-Meier
-  npar.out <- enparCensored(y1, y2, ci = TRUE, pivot.statistic = "t", ci.sample.size = N, left.censored.min="DL")
+  npar.out <- enparCensored(y1, y2, ci = TRUE, pivot.statistic = "t", ci.sample.size = "Total", left.censored.min="DL")
   KMmean <- npar.out$parameters[1]
   std.err <- npar.out$parameters[3]
   KMsd <- signif(npar.out$parameters[2], 4)


### PR DESCRIPTION
The parameter ci.sample.size should be either "Total" or "Censored" and not a numeric value.